### PR TITLE
For larger OpenAPI specs the default timeout is

### DIFF
--- a/flow-nodes/api-builder-plugin-petstore/package.json
+++ b/flow-nodes/api-builder-plugin-petstore/package.json
@@ -33,6 +33,6 @@
 		"mocha": "^6.1.4"
 	},
 	"scripts": {
-		"test": "mocha ./test --recursive -R spec"
+		"test": "mocha ./test --recursive -R spec --timeout 7000"
 	}
 }


### PR DESCRIPTION
not sufficient.